### PR TITLE
Proper detection of rendering on Retina displays

### DIFF
--- a/src/java/cleargl/ClearGLWindow.java
+++ b/src/java/cleargl/ClearGLWindow.java
@@ -1,11 +1,8 @@
 package cleargl;
 
 import java.awt.Component;
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
 import java.io.PrintStream;
 import java.util.List;
-import java.lang.reflect.Field;
 
 import com.jogamp.nativewindow.CapabilitiesImmutable;
 import com.jogamp.nativewindow.WindowClosingProtocol.WindowClosingMode;
@@ -375,7 +372,7 @@ public class ClearGLWindow implements ClearGLDisplayable
 	{
 		mGlWindow.display();
 	}
-	
+
 	public static boolean isRetina(GL pGL) {
 		int[] trialSizes = new int[2];
 

--- a/src/java/cleargl/ClearGLWindow.java
+++ b/src/java/cleargl/ClearGLWindow.java
@@ -1,8 +1,11 @@
 package cleargl;
 
 import java.awt.Component;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
 import java.io.PrintStream;
 import java.util.List;
+import java.lang.reflect.Field;
 
 import com.jogamp.nativewindow.CapabilitiesImmutable;
 import com.jogamp.nativewindow.WindowClosingProtocol.WindowClosingMode;
@@ -13,6 +16,7 @@ import com.jogamp.newt.event.KeyListener;
 import com.jogamp.newt.event.MouseListener;
 import com.jogamp.newt.event.WindowAdapter;
 import com.jogamp.newt.opengl.GLWindow;
+import com.jogamp.opengl.GL;
 import com.jogamp.opengl.DefaultGLCapabilitiesChooser;
 import com.jogamp.opengl.GLAutoDrawable;
 import com.jogamp.opengl.GLCapabilities;
@@ -263,12 +267,12 @@ public class ClearGLWindow implements ClearGLDisplayable
 																				final float zFar)
 	{
 		if (mProjectionMatrix != null)
-			mProjectionMatrix.setOrthoProjectionMatrix(	left,
-																									right,
-																									bottom,
-																									top,
-																									zNear,
-																									zFar);
+			mProjectionMatrix.setOrthoProjectionMatrix(left,
+              right,
+              bottom,
+              top,
+              zNear,
+              zFar);
 	}
 
 	/* (non-Javadoc)
@@ -370,6 +374,21 @@ public class ClearGLWindow implements ClearGLDisplayable
 	public void display()
 	{
 		mGlWindow.display();
+	}
+	
+	public static boolean isRetina(GL pGL) {
+		int[] trialSizes = new int[2];
+
+		trialSizes[0] = 512;
+		trialSizes[1] = 512;
+
+		pGL.getContext().getGLDrawable().getNativeSurface().convertToPixelUnits(trialSizes);
+
+		if(trialSizes[0] == 512 && trialSizes[1] == 512) {
+			return false;
+		} else {
+			return true;
+		}
 	}
 
 	/* (non-Javadoc)

--- a/src/java/cleargl/ClearTextRenderer.java
+++ b/src/java/cleargl/ClearTextRenderer.java
@@ -1,5 +1,8 @@
 package cleargl;
 
+import com.jogamp.newt.NewtFactory;
+import jogamp.newt.awt.NewtFactoryAWT;
+
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
@@ -78,12 +81,22 @@ public class ClearTextRenderer
 			font = new JLabel().getFont();
 		}
 
+    final int scaleFactor = ClearGLWindow.isRetina(mGL) ? 2 : 1;
+
 		final int windowSizeX = mGL.getContext()
 																.getGLDrawable()
-																.getSurfaceWidth() / 2;
+																.getSurfaceWidth() / scaleFactor;
 		final int windowSizeY = mGL.getContext()
 																.getGLDrawable()
-																.getSurfaceHeight() / 2;
+																.getSurfaceHeight() / scaleFactor;
+
+		int[] windowSizes = new int[2];
+		windowSizes[0] = windowSizeX;
+		windowSizes[1] = windowSizeY;
+
+		System.out.println(windowSizes[0] + ", " + windowSizes[1]);
+		mGL.getContext().getGLDrawable().getNativeSurface().convertToPixelUnits(windowSizes);
+		System.out.println(windowSizes[0] + ", " + windowSizes[1]);
 
 		final int width = text.length() * font.getSize();
 		final int height = font.getSize();

--- a/src/java/cleargl/ClearTextRenderer.java
+++ b/src/java/cleargl/ClearTextRenderer.java
@@ -90,14 +90,6 @@ public class ClearTextRenderer
 																.getGLDrawable()
 																.getSurfaceHeight() / scaleFactor;
 
-		int[] windowSizes = new int[2];
-		windowSizes[0] = windowSizeX;
-		windowSizes[1] = windowSizeY;
-
-		System.out.println(windowSizes[0] + ", " + windowSizes[1]);
-		mGL.getContext().getGLDrawable().getNativeSurface().convertToPixelUnits(windowSizes);
-		System.out.println(windowSizes[0] + ", " + windowSizes[1]);
-
 		final int width = text.length() * font.getSize();
 		final int height = font.getSize();
 

--- a/src/java/cleargl/ClearTextRenderer.java
+++ b/src/java/cleargl/ClearTextRenderer.java
@@ -1,8 +1,5 @@
 package cleargl;
 
-import com.jogamp.newt.NewtFactory;
-import jogamp.newt.awt.NewtFactoryAWT;
-
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;


### PR DESCRIPTION
- drawTextAtPosition() will now detect whether the window of the OpenGL
  context it belongs to resides on a Retina display.
- the logic behind this is implemented in `ClearGLWindow#isRetina(GL)`
