### PR TITLE
Fix video recording in ClearGL

### DIFF
--- a/src/java/cleargl/util/recorder/GLVideoRecorder.java
+++ b/src/java/cleargl/util/recorder/GLVideoRecorder.java
@@ -328,7 +328,6 @@ public class GLVideoRecorder
 
 				final GL lGL = pDrawable.getGL();
 
-				lGL.getGL3().glReadBuffer(GL.GL_BACK);
 				lGL.glPixelStorei(GL.GL_PACK_ALIGNMENT, 1);
 				lGL.glReadPixels(0, // GLint x
 													0, // GLint y
@@ -361,9 +360,6 @@ public class GLVideoRecorder
 
 						}
 					});
-
-					mImageCounter++;
-					// System.out.println("saved image!");
 				}
 			}
 
@@ -460,6 +456,7 @@ public class GLVideoRecorder
 														pWidth);
 
 			ImageIO.write(lBufferedImage, "PNG", pOutputFile);
+			mImageCounter++;
 		}
 		catch (final Throwable e)
 		{


### PR DESCRIPTION
- first, the backbuffer (which we didn't use) was queried for image
  data - fixed by this commit
- second, for asynchronous writing, the image counter was not
  incremented correctly - also fixed with this commit
