### PR TITLE
  Fix getSurfaceWidth() returning the surface height

### DIFF
--- a/src/main/java/cleargl/ClearGLWindow.java
+++ b/src/main/java/cleargl/ClearGLWindow.java
@@ -589,7 +589,7 @@ public class ClearGLWindow implements ClearGLDisplayable {
 
 	@Override
 	public int getSurfaceWidth() {
-		return mGlWindow.getSurfaceHeight();
+		return mGlWindow.getSurfaceWidth();
 	}
 
 	@Override


### PR DESCRIPTION
  ClearGLWindow.getSurfaceWidth() returned mGlWindow.getSurfaceHeight()
  instead of getSurfaceWidth() — a copy-paste error. Callers asking for
  the surface width (e.g. aspect-ratio calculations and overlay sizing in
  ClearVolume) received the height, producing incorrect results on
  non-square windows.